### PR TITLE
feat: Support SWT Snippets

### DIFF
--- a/examples/org.eclipse.swt.snippets/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.snippets/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-SymbolicName: org.eclipse.swt.snippets;singleton:=true
 Bundle-Version: 3.4.0
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Require-Bundle: org.eclipse.swt
+Require-Bundle: org.eclipse.swt,
+ org.eclipse.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.snippets
 Bundle-ActivationPolicy: lazy

--- a/examples/org.eclipse.swt.snippets/plugin.xml
+++ b/examples/org.eclipse.swt.snippets/plugin.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+
+	<extension
+		point="org.eclipse.ui.menus">
+		<menuContribution
+			locationURI="menu:org.eclipse.ui.main.menu">
+			<menu
+				id="window"
+				label="Window">
+				<command
+					commandId="org.eclipse.swt.snippets.launcher"
+					label="SWT Snippets"
+					style="push">
+				</command>
+			</menu>
+		</menuContribution>
+	</extension>
+      <extension
+            point="org.eclipse.ui.commands">
+            <command
+                  id="org.eclipse.swt.snippets.launcher"
+                  name="SWT Snippets">
+            </command>
+      </extension>
+      <extension point="org.eclipse.ui.handlers">
+            <handler commandId="org.eclipse.swt.snippets.launcher"
+                  class="org.eclipse.swt.snippets.SnippetHandler" />
+      </extension>
+
+</plugin>

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetExplorer.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetExplorer.java
@@ -89,8 +89,8 @@ public class SnippetExplorer {
 	 */
 	private static final int SHUTDOWN_GRACE_TIME_MS = 5000;
 	/** Link to online snippet source. Used if no local source is available. */
-	private static final String SNIPPET_SOURCE_LINK_TEMPLATE = "https://github.com/eclipse-platform/"
-			+ "eclipse.platform.swt.git/tree/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/%s.java";
+	private static final String SNIPPET_SOURCE_LINK_TEMPLATE = "https://github.com/unknowIfGuestInDream/tlstudio"
+			+ "/tree/master/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/%s.java";
 
 	/**
 	 * Whether or not SWT support creating of multiple {@link Display} instances on

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetHandler.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetHandler.java
@@ -1,0 +1,15 @@
+package org.eclipse.swt.snippets;
+
+import org.eclipse.core.commands.*;
+
+public class SnippetHandler extends AbstractHandler{
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+        try {
+        	SnippetExplorer.main(null);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return Integer.valueOf(0);
+	}
+}

--- a/features/com.tlcsdm.tlstudio.examples.swt.rcp.feature/feature.xml
+++ b/features/com.tlcsdm.tlstudio.examples.swt.rcp.feature/feature.xml
@@ -66,4 +66,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.swt.snippets"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/releng/com.tlcsdm.tlstudio.examples.swt.rcp/plugin.xml
+++ b/releng/com.tlcsdm.tlstudio.examples.swt.rcp/plugin.xml
@@ -113,9 +113,6 @@
 		<product
 			name="SWT Examples Product"
 			application="com.tlcsdm.tlstudio.examples.swt.rcp.application">
-			<property 
-			    name="aboutText" 
-			    value="%aboutText" />
 			<property
 				name="windowImages"
 				value="icons/eclipse16.png,icons/eclipse32.png,icons/eclipse48.png,icons/eclipse64.png,icons/eclipse128.png,icons/eclipse256.png" />
@@ -135,10 +132,10 @@
 				name="startupProgressRect"
 				value="0,385,600,15">
 			</property>
-			<property
-				name="preferenceCustomization"
-				value="plugin_customization.ini">
-			</property>
+   <property
+         name="preferenceCustomization"
+         value="plugin_customization.ini">
+   </property>
 		</product>
 	</extension>
 

--- a/releng/com.tlcsdm.tlstudio.examples.swt.rcp/src/com/tlcsdm/tlstudio/examples/swt/rcp/Perspective.java
+++ b/releng/com.tlcsdm.tlstudio.examples.swt.rcp/src/com/tlcsdm/tlstudio/examples/swt/rcp/Perspective.java
@@ -23,8 +23,8 @@ public class Perspective implements IPerspectiveFactory {
 		layout.createFolder("leftBottom", IPageLayout.TOP, 0.3f, "left").addView(LAYOUT_VIEWID);
 		layout.createFolder("right", IPageLayout.LEFT, 0.5f, layout.getEditorArea());
 		layout.createFolder("rightTop", IPageLayout.TOP, 0.25f, "right").addView(CONTROL_VIEWID);
-		layout.createFolder("rightTop1", IPageLayout.TOP, 0.5f, "right").addView(PAINT_VIEWID);
-		layout.createFolder("rightBottom", IPageLayout.TOP, 0.25f, "right").addView(CONSOLEVIEWID);
+		layout.createFolder("rightTop1", IPageLayout.TOP, 0.6f, "right").addView(PAINT_VIEWID);
+		layout.createFolder("rightBottom", IPageLayout.TOP, 0.15f, "right").addView(CONSOLEVIEWID);
 	}
 
 }


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #54

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a menu option to launch SWT Snippets from the "Window" menu in the Eclipse plugin.
  - Introduced a command and handler for executing the SWT Snippets launcher.

- **Enhancements**
  - Updated the URL template for online snippet sources to a new repository.

- **Bug Fixes**
  - Adjusted layout percentages for views to improve perspective layout in the application.

- **Chores**
  - Added `org.eclipse.ui` as a required bundle in the manifest file.
  - Included the `org.eclipse.swt.snippets` plugin in the feature definition.
  - Removed the `aboutText` property and adjusted formatting in the product declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->