### PR TITLE
feat: Upgrade pom

### DIFF
--- a/examples/org.eclipse.swt.examples.watchdog/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.examples.watchdog/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.swt.examples.watchdog;singleton:=true
+Bundle-Vendor: Eclipse.org
 Bundle-Version: 1.2.0.qualifier
 Bundle-Activator: org.eclipse.swt.examples.watchdog.WatchdogPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
 		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
 		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-		<maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
+		<maven-dependency-plugin.version>3.7.0</maven-dependency-plugin.version>
 		<maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
 		<maven-help-plugin.version>3.4.1</maven-help-plugin.version>
 		<maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>

--- a/releng/com.tlcsdm.tlstudio.examples.swt.rcp/META-INF/MANIFEST.MF
+++ b/releng/com.tlcsdm.tlstudio.examples.swt.rcp/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Rcp
+Bundle-Name: SWT Examples RCP
 Bundle-SymbolicName: com.tlcsdm.tlstudio.examples.swt.rcp;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: com.tlcsdm.tlstudio.examples.swt.rcp.Activator
-Bundle-Vendor: TLCSDM
+Bundle-Vendor: Tlcsdm
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.apache.felix.scr,

--- a/releng/com.tlcsdm.tlstudio.examples.swt.rcp/about.html
+++ b/releng/com.tlcsdm.tlstudio.examples.swt.rcp/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>About</title>
+</head>
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
+
+</body>
+</html>

--- a/releng/com.tlcsdm.tlstudio.examples.swt.rcp/build.properties
+++ b/releng/com.tlcsdm.tlstudio.examples.swt.rcp/build.properties
@@ -7,4 +7,5 @@ bin.includes = plugin.xml,\
                splash.bmp,\
                OSGI-INF/,\
                plugin_customization.ini,\
-               product_lg.gif
+               product_lg.gif,\
+               about.html


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `about.html` to provide licensing and redistribution information for SWT Examples RCP.

- **Updates**
  - Updated `maven-dependency-plugin` to version 3.7.0 for better dependency management.

- **Improvements**
  - Updated vendor details for `org.eclipse.swt.examples.watchdog` and SWT Examples RCP for better clarity.
  - Updated `Bundle-Name` for SWT Examples RCP to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->