### PR TITLE
feat: Add CollapsibleComposite

### DIFF
--- a/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/CollapsibleComposite.java
+++ b/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/CollapsibleComposite.java
@@ -1,0 +1,134 @@
+package com.tlcsdm.tlstudio.widgets.custom;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+
+public class CollapsibleComposite extends Composite {
+
+	public enum Direction {
+		LEFT, RIGHT, TOP, BOTTOM
+	}
+
+	public enum ButtonPosition {
+		LEADING, TRAILING
+	}
+
+	public interface CollapseListener {
+		void onCollapse();
+
+		void onExpand();
+	}
+
+	private boolean collapsed = false;
+	private Composite contentArea;
+	private Button toggleButton;
+	private Direction direction;
+	private ButtonPosition buttonPosition;
+	private List<CollapseListener> listeners = new ArrayList<>();
+
+	public CollapsibleComposite(Composite parent, int style, Direction direction, ButtonPosition buttonPosition) {
+		super(parent, style);
+		this.direction = direction;
+		this.buttonPosition = buttonPosition;
+
+		createControls();
+	}
+
+	private void createControls() {
+		boolean horizontal = (direction == Direction.LEFT || direction == Direction.RIGHT);
+		GridLayout layout = new GridLayout(horizontal ? 2 : 1, false);
+		layout.marginWidth = 0;
+		layout.marginHeight = 0;
+		this.setLayout(layout);
+
+		if (buttonPosition == ButtonPosition.LEADING) {
+			createToggleButton();
+			createContentArea();
+		} else {
+			createContentArea();
+			createToggleButton();
+		}
+
+		updateLayout();
+	}
+
+	private void createToggleButton() {
+		toggleButton = new Button(this, SWT.PUSH);
+		toggleButton.setText(getToggleText());
+		toggleButton.setLayoutData(new GridData(SWT.FILL, SWT.FILL,
+				this.direction.equals(Direction.TOP) || this.direction.equals(Direction.BOTTOM),
+				this.direction.equals(Direction.LEFT) || this.direction.equals(Direction.RIGHT)));
+		toggleButton.addListener(SWT.Selection, e -> toggle());
+	}
+
+	private void createContentArea() {
+		contentArea = new Composite(this, SWT.BORDER);
+		contentArea.setLayout(new FillLayout());
+		contentArea.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+	}
+
+	private String getToggleText() {
+		switch (direction) {
+		case LEFT:
+			return collapsed ? ">" : "<";
+		case RIGHT:
+			return collapsed ? "<" : ">";
+		case TOP:
+			return collapsed ? "v" : "^";
+		case BOTTOM:
+			return collapsed ? "^" : "v";
+		}
+		return "";
+	}
+
+	public Composite getContentArea() {
+		return contentArea;
+	}
+
+	public void addCollapseListener(CollapseListener listener) {
+		listeners.add(listener);
+	}
+
+	public void toggle() {
+		collapsed = !collapsed;
+		updateLayout();
+
+		// 回调监听器
+		if (collapsed) {
+			listeners.forEach(CollapseListener::onCollapse);
+		} else {
+			listeners.forEach(CollapseListener::onExpand);
+		}
+	}
+
+	public void collapse() {
+		if (!collapsed) {
+			collapsed = true;
+			updateLayout();
+			listeners.forEach(CollapseListener::onCollapse);
+		}
+	}
+
+	public void expand() {
+		if (collapsed) {
+			collapsed = false;
+			updateLayout();
+			listeners.forEach(CollapseListener::onExpand);
+		}
+	}
+
+	private void updateLayout() {
+		contentArea.setVisible(!collapsed);
+		((GridData) contentArea.getLayoutData()).exclude = collapsed;
+		toggleButton.setText(getToggleText());
+		this.layout(true, true);
+	}
+
+}

--- a/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/example/CollapsibleCompositeSnippet.java
+++ b/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/example/CollapsibleCompositeSnippet.java
@@ -1,0 +1,57 @@
+package com.tlcsdm.tlstudio.widgets.example;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+
+import com.tlcsdm.tlstudio.widgets.custom.CollapsibleComposite;
+
+public class CollapsibleCompositeSnippet {
+
+	public CollapsibleCompositeSnippet(Shell shell) {
+		// 创建可收缩组件，设置方向为向左收缩
+		CollapsibleComposite collapsible = new CollapsibleComposite(shell, SWT.NONE,
+				CollapsibleComposite.Direction.LEFT, CollapsibleComposite.ButtonPosition.TRAILING);
+
+		// 获取内容区域，往里面加控件
+		Composite content = collapsible.getContentArea();
+		new Label(content, SWT.NONE).setText("我是可收缩区域的内容！");
+
+		collapsible.addCollapseListener(new CollapsibleComposite.CollapseListener() {
+			@Override
+			public void onCollapse() {
+				System.out.println("内容已折叠");
+			}
+
+			@Override
+			public void onExpand() {
+				System.out.println("内容已展开");
+			}
+		});
+
+		// 你可以手动控制：
+		// composite.collapse();
+		// composite.expand();
+
+	}
+
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setLayout(new FillLayout());
+		new CollapsibleCompositeSnippet(shell);
+		shell.open();
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
+
+		display.dispose();
+
+	}
+
+}


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #295

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Introduce a new CollapsibleComposite widget for SWT that supports configurable collapse directions, toggle button positions, and expand/collapse listeners, and include an example snippet demonstrating its usage.

New Features:
- Implement CollapsibleComposite component with configurable collapse directions, button positions, and collapse/expand methods with listener callbacks.
- Add CollapsibleCompositeSnippet example showcasing instantiation and use of the new collapsible composite in an SWT application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a collapsible content widget with customizable collapse direction and toggle button position.
  - Added support for programmatically collapsing or expanding the content area and for listening to collapse/expand events.
  - Provided an example demonstrating how to use the new collapsible widget within an application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->