### PR TITLE
feat: Add TitledSeparator

### DIFF
--- a/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/TitledSeparator.java
+++ b/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/TitledSeparator.java
@@ -1,0 +1,306 @@
+package com.tlcsdm.tlstudio.widgets.custom;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Layout;
+
+import com.tlcsdm.tlstudio.widgets.utils.SWTGraphicUtil;
+
+/**
+ * Instances of this class provide a separator with a title and/or an image.
+ * <p>
+ * <dl>
+ * <dt><b>Styles:</b></dt>
+ * <dd>BORDER</dd>
+ * <dt><b>Events:</b></dt>
+ * <dd>(none)</dd>
+ * </dl>
+ * </p>
+ */
+public class TitledSeparator extends Composite {
+
+	private int alignment;
+	private Image image;
+	private String text;
+
+	/**
+	 * Constructs a new instance of this class given its parent and a style value
+	 * describing its behavior and appearance.
+	 * <p>
+	 * The style value is either one of the style constants defined in class
+	 * <code>SWT</code> which is applicable to instances of this class, or must be
+	 * built by <em>bitwise OR</em>'ing together (that is, using the
+	 * <code>int</code> "|" operator) two or more of those <code>SWT</code> style
+	 * constants. The class description lists the style constants that are
+	 * applicable to the class. Style bits are also inherited from superclasses.
+	 * </p>
+	 *
+	 * @param parent a composite control which will be the parent of the new
+	 *               instance (cannot be null)
+	 * @param style  the style of control to construct
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the parent
+	 *                                     is null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     parent</li>
+	 *                                     </ul>
+	 *
+	 */
+	public TitledSeparator(final Composite parent, final int style) {
+		super(parent, style);
+		alignment = SWT.LEFT;
+
+		final Color originalColor = new Color(getDisplay(), 0, 88, 150);
+		setForeground(originalColor);
+
+		final Font originalFont;
+		final FontData[] fontData = getFont().getFontData();
+		if (fontData != null && fontData.length > 0) {
+			final FontData fd = fontData[0];
+			fd.setStyle(SWT.BOLD);
+			originalFont = new Font(getDisplay(), fd);
+			setFont(originalFont);
+		} else {
+			originalFont = null;
+		}
+
+		addListener(SWT.Resize, e -> redrawComposite());
+
+		SWTGraphicUtil.addDisposer(this, originalColor);
+		SWTGraphicUtil.addDisposer(this, originalFont);
+	}
+
+	/**
+	 * Redraw the composite
+	 */
+	private void redrawComposite() {
+		// Dispose previous content
+		for (final Control c : getChildren()) {
+			c.dispose();
+		}
+
+		int numberOfColumns = 1;
+
+		if (text != null) {
+			numberOfColumns++;
+		}
+
+		if (image != null) {
+			numberOfColumns++;
+		}
+
+		if (alignment == SWT.CENTER) {
+			numberOfColumns++;
+		}
+
+		super.setLayout(new GridLayout(numberOfColumns, false));
+		createContent();
+	}
+
+	/**
+	 * Create the content
+	 */
+	private void createContent() {
+		switch (alignment) {
+		case SWT.CENTER:
+			createSeparator();
+			createTitle();
+			createSeparator();
+			break;
+		case SWT.LEFT:
+			createTitle();
+			createSeparator();
+			break;
+		default:
+			createSeparator();
+			createTitle();
+			break;
+		}
+	}
+
+	/**
+	 * Create a separator
+	 */
+	private void createSeparator() {
+		final Label separator = new Label(this, SWT.SEPARATOR | SWT.HORIZONTAL);
+		separator.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, true, false));
+	}
+
+	/**
+	 * Create the title
+	 */
+	private void createTitle() {
+		if (image != null) {
+			final Label imageLabel = createLabel();
+			imageLabel.setImage(image);
+		}
+
+		if (text != null && !text.trim().equals("")) {
+			final Label textLabel = createLabel();
+			textLabel.setText(text);
+		}
+	}
+
+	/**
+	 * @return a SWT label
+	 */
+	private Label createLabel() {
+		final Label label = new Label(this, SWT.NONE);
+		label.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, false, false));
+		label.setFont(getFont());
+		label.setForeground(getForeground());
+		label.setBackground(getBackground());
+		return label;
+	}
+
+	/**
+	 * @see org.eclipse.swt.widgets.Composite#setLayout(org.eclipse.swt.widgets.Layout)
+	 */
+	@Override
+	public void setLayout(final Layout layout) {
+		throw new UnsupportedOperationException("Not supported");
+	}
+
+	/**
+	 * Returns a value which describes the position of the text or image in the
+	 * receiver. The value will be one of <code>LEFT</code>, <code>RIGHT</code> or
+	 * <code>CENTER</code>.
+	 *
+	 * @return the alignment
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+
+	public int getAlignment() {
+		checkWidget();
+		return alignment;
+	}
+
+	/**
+	 * Returns the receiver's image if it has one, or null if it does not.
+	 *
+	 * @return the receiver's image
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Image getImage() {
+		checkWidget();
+		return image;
+	}
+
+	/**
+	 * Returns the receiver's text.
+	 *
+	 * @return the receiver's text
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public String getText() {
+		checkWidget();
+		return text;
+	}
+
+	/**
+	 * Controls how text will be displayed in the receiver. The argument should be
+	 * one of <code>LEFT</code>, <code>RIGHT</code> or <code>CENTER</code>.
+	 *
+	 * @param alignment the new alignment
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public void setAlignment(final int alignment) {
+		checkWidget();
+		this.alignment = alignment;
+		redrawComposite();
+	}
+
+	/**
+	 * Sets the receiver's image to the argument, which may be null indicating that
+	 * no image should be displayed.
+	 *
+	 * @param image the image to display on the receiver (may be null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the image
+	 *                                     has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setImage(final Image image) {
+		checkWidget();
+		this.image = image;
+		redrawComposite();
+	}
+
+	/**
+	 * Sets the receiver's text.
+	 *
+	 * @param string the new text
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the text is
+	 *                                     null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setText(final String text) {
+		checkWidget();
+		this.text = text;
+		redrawComposite();
+	}
+}

--- a/examples/com.tlcsdm.tlstudio.widgets.snippets/src/com/tlcsdm/tlstudio/widgets/example/custom/TitledSeparatorSnippet.java
+++ b/examples/com.tlcsdm.tlstudio.widgets.snippets/src/com/tlcsdm/tlstudio/widgets/example/custom/TitledSeparatorSnippet.java
@@ -1,0 +1,94 @@
+package com.tlcsdm.tlstudio.widgets.example.custom;
+
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+import com.tlcsdm.tlstudio.widgets.custom.TitledSeparator;
+import com.tlcsdm.tlstudio.widgets.utils.SWTGraphicUtil;
+
+/**
+ * This snippet demonstrates the TitledSeparator widget
+ *
+ */
+public class TitledSeparatorSnippet {
+
+	private static final String IMAGE = "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAFo9M"
+			+ "/3AAAAB3RJTUUH2woHCQsOaNepFwAAAAlwSFlzAAAewgAAHsIBbtB1"
+			+ "PgAAAARnQU1BAACxjwv8YQUAAAI+SURBVHjalVF7SNNRFP5+mzhkGbX"
+			+ "IZSqyBg2igtQFTsyBKURJjB7EgkhSe+wP6QG9/7WCaaRgFEWjKKEsMh"
+			+ "2Z6VZiVKQLVKYVuVyauWCQSkG636l7ZXev+qMP7j2H8/ju/c6RiAgMC"
+			+ "nY1nygjSUS0pZ3U+nKIwCLnCxdSuUlLzOcll5xfqedTCLKvG6InDM42"
+			+ "7aylPaWZ8xlWce/4Fnr9PjjPMdVmp4rZQzx51FUY4fC03yfXdRv3v/"
+			+ "2QccEZkJifFCYf839G1dlGxIMz5FnraF91BbxQIjDB/4H8LwT9utHIE"
+			+ "xcfDJLjrpf7qiVquA8UQL1mkZSgIx7iD/Ydy0i9OBlTw9+x8rADFotF"
+			+ "EsIZDKadMOZsRjBVhVb7wUSGomIzt6dNJXje9SxWBRu7PnsFvPXbedD"
+			+ "mqcZkx0b+hMRGODFF6JxTCYkZ8gy6m2+h984RSYGGEtxseiKSYbh3U+QJ"
+			+ "hm3HmmjkFSBnKrGrWIeTlUYppiAa0XsJTf6EUpsCvfWykJ6wimiwea2dm"
+			+ "Ub/glTRzCwbz5xSi9pHAzEkSfGMuuzlKDp1A/l+F/zjclTcjMeOyoTfKuI"
+			+ "DPsMZtNWUcz8rSycOa2a5f0po6QvS/pohuBry4CMF2sd+iSI2YXP6LHI1I"
+			+ "ZTZ+nD1XA625moiQ3xbZySDvgCNgQ14s3QT0tLlmLXI40Fuh/8otib7UZ1"
+			+ "2G4NdPVhf3yvxqlV7r/HAaL8bHx56eDMjETozNPwEWgaQMvIU7z6+wOqqK3" + "/fwv/iN7ZiFLq3HVKbAAAAAElFTkSuQmCC";
+
+	/**
+	 * @param args
+	 */
+	public static void main(final String[] args) {
+		final Display display = new Display();
+		final Shell shell = new Shell(display);
+		shell.setLayout(new GridLayout(1, false));
+
+		final byte[] imageBytes = Base64.getDecoder().decode(IMAGE);
+		final Image icon = new Image(display, new ByteArrayInputStream(imageBytes));
+		final Font font = new Font(display, "Courier New", 18, SWT.BOLD | SWT.ITALIC);
+
+		// Default separator (no image, title aligned on the left)
+		final TitledSeparator sep1 = new TitledSeparator(shell, SWT.NONE);
+		sep1.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
+		sep1.setText("Customer Info");
+
+		// Separator with image
+		final TitledSeparator sep2 = new TitledSeparator(shell, SWT.NONE);
+		sep2.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
+		sep2.setText("Customer Info");
+		sep2.setImage(icon);
+
+		// Separator aligned on the right
+		final TitledSeparator sep3 = new TitledSeparator(shell, SWT.NONE);
+		sep3.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
+		sep3.setText("Customer Info");
+		sep3.setAlignment(SWT.RIGHT);
+
+		// Custom font & text color
+		final TitledSeparator sep4 = new TitledSeparator(shell, SWT.NONE);
+		sep4.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
+		sep4.setText("Customized Color and Font");
+		sep4.setAlignment(SWT.CENTER);
+
+		sep4.setForeground(display.getSystemColor(SWT.COLOR_DARK_RED));
+		sep4.setFont(font);
+
+		shell.setSize(640, 350);
+		shell.pack();
+		shell.open();
+		SWTGraphicUtil.centerShell(shell);
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+		icon.dispose();
+		font.dispose();
+
+		display.dispose();
+	}
+
+}


### PR DESCRIPTION
Close #308

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Add TitledSeparator custom SWT widget with configurable title, image, and alignment, and provide a usage example snippet showcasing different setups

New Features:
- Introduce TitledSeparator composite supporting optional text, image, and alignment for SWT widgets
- Add example snippet demonstrating various TitledSeparator configurations (default, with image, alignment, custom font/color)