### PR TITLE
feat: Add RoundedSwitch

### DIFF
--- a/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/RoundedCheckbox.java
+++ b/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/RoundedCheckbox.java
@@ -1,0 +1,548 @@
+package com.tlcsdm.tlstudio.widgets.custom;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.internal.DPIUtil;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+
+/**
+ * Instances of this class provide a checkbox button.<br/>
+ * Please notive that this widget draws only the checkbox (you can not attach a
+ * text like regular <code>Button</code> SWT Widget)
+ * <p>
+ * <dl>
+ * <dt><b>Styles:</b></dt>
+ * <dd>BORDER</dd>
+ * <dt><b>Events:</b></dt>
+ * <dd>Selection</dd>
+ * </dl>
+ * </p>
+ */
+@SuppressWarnings("restriction")
+public class RoundedCheckbox extends AbstractCustomCanvas {
+	private static final int DEFAULT_WIDTH = 20;
+	private static final int DEFAULT_HEIGHT = 20;
+	private boolean selected;
+	private boolean grayed;
+	private Color unselectedColor, selectionBackground, selectionForeground, hoverColor;
+	private final Color disabledColor;
+	private GC gc;
+	private boolean cursorInside;
+
+	/**
+	 * Constructs a new instance of this class given its parent and a style value
+	 * describing its behavior and appearance.
+	 * <p>
+	 * The style value is either one of the style constants defined in class
+	 * <code>SWT</code> which is applicable to instances of this class, or must be
+	 * built by <em>bitwise OR</em>'ing together (that is, using the
+	 * <code>int</code> "|" operator) two or more of those <code>SWT</code> style
+	 * constants. The class description lists the style constants that are
+	 * applicable to the class. Style bits are also inherited from superclasses.
+	 * </p>
+	 *
+	 * @param parent a composite control which will be the parent of the new
+	 *               instance (cannot be null)
+	 * @param style  the style of control to construct
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the parent
+	 *                                     is null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     parent</li>
+	 *                                     </ul>
+	 *
+	 */
+	public RoundedCheckbox(final Composite parent, final int style) {
+		super(parent, checkStyle(style) | SWT.DOUBLE_BUFFERED);
+		disabledColor = getAndDisposeColor(204, 204, 204);
+		selectionBackground = getAndDisposeColor(0, 122, 255);
+		selectionForeground = getAndDisposeColor(255, 255, 255);
+		unselectedColor = getDisplay().getSystemColor(SWT.COLOR_BLACK);
+		hoverColor = getAndDisposeColor(56, 143, 188);
+
+		addListener(SWT.Paint, e -> {
+			gc = e.gc;
+			drawElement();
+		});
+
+		addListener(SWT.MouseUp, e -> onClick(e));
+		addListener(SWT.KeyUp, e -> onKeyPress(e));
+
+		addListener(SWT.MouseEnter, e -> {
+			cursorInside = true;
+			redraw();
+		});
+		addListener(SWT.MouseExit, e -> {
+			cursorInside = false;
+			redraw();
+		});
+	}
+
+	private static int checkStyle(final int style) {
+		if ((style & SWT.BORDER) != 0) {
+			return style & ~SWT.BORDER;
+		}
+		return 0;
+	}
+
+	private void drawElement() {
+		gc.setAdvanced(true);
+		gc.setAntialias(SWT.ON);
+		final Color previousForeground = gc.getForeground();
+		final Color previousBackground = gc.getBackground();
+
+		if (!selected) {
+			drawUnselected();
+		} else {
+			if (grayed) {
+				drawGrayed();
+			} else {
+				drawTicker();
+			}
+		}
+
+		gc.setBackground(previousBackground);
+		gc.setForeground(previousForeground);
+
+	}
+
+	private void drawUnselected() {
+		final Rectangle rect = getClientArea();
+		Color color;
+		if (isEnabled()) {
+			color = cursorInside ? hoverColor : unselectedColor;
+		} else {
+			color = disabledColor;
+		}
+
+		gc.setForeground(color);
+		gc.setLineWidth(1);
+		gc.drawOval(2, 2, rect.width - 4, rect.height - 4);
+	}
+
+	private void drawGrayed() {
+		final Rectangle rect = getClientArea();
+		Color color;
+		if (isEnabled()) {
+			color = cursorInside ? hoverColor : selectionBackground;
+		} else {
+			color = disabledColor;
+		}
+
+		gc.setForeground(color);
+		gc.setLineWidth(1);
+		gc.drawOval(2, 2, rect.width - 4, rect.height - 4);
+		gc.setBackground(color);
+		gc.fillOval(5, 5, rect.width - 9, rect.height - 9);
+
+	}
+
+	private void drawTicker() {
+		final Rectangle rect = getClientArea();
+		Color color;
+		if (isEnabled()) {
+			color = cursorInside ? hoverColor : selectionBackground;
+		} else {
+			color = disabledColor;
+		}
+
+		gc.setBackground(color);
+		gc.fillOval(2, 2, rect.width - 4, rect.height - 4);
+
+		gc.setForeground(selectionForeground);
+		gc.setLineWidth(2);
+		final int centerX = rect.width / 2;
+		final int centerY = rect.height / 2;
+		gc.drawLine(5, centerY, 8, centerY + 4);
+		gc.drawLine(8, centerY + 4, centerX + 5, centerY - 3);
+
+	}
+
+	private void onClick(Event e) {
+		final Rectangle rect = getClientArea();
+		final int centerX = (rect.width - rect.x) / 2;
+		final int centerY = (rect.height - rect.y) / 2;
+		final int distance = (int) Math.sqrt(Math.abs(e.x - centerX ^ 2 - (e.y - centerY) ^ 2));
+		if (distance < rect.width - 4) {
+			if (fireSelectionListeners(this, e)) {
+				setSelection(!selected);
+			}
+		}
+	}
+
+	private void onKeyPress(Event e) {
+		if (e.character == ' ' || e.character == '+') {
+			setSelection(!selected);
+		}
+	}
+
+	/**
+	 * Adds the listener to the collection of listeners who will be notified when
+	 * the control is selected by the user, by sending it one of the messages
+	 * defined in the <code>SelectionListener</code> interface.
+	 * <p>
+	 * <code>widgetDefaultSelected</code> is not called.
+	 * </p>
+	 *
+	 * @param listener the listener which should be notified when the control is
+	 *                 selected by the user,
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the listener
+	 *                                     is null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 *
+	 * @see SelectionListener
+	 * @see #removeSelectionListener
+	 * @see SelectionEvent
+	 */
+	public void addSelectionListener(final SelectionListener listener) {
+		addTypedListener(listener, SWT.Selection);
+	}
+
+	/**
+	 * @see org.eclipse.swt.widgets.Control#computeSize(int, int, boolean)
+	 */
+	@Override
+	public Point computeSize(int wHint, int hHint, boolean changed) {
+		wHint = wHint != SWT.DEFAULT ? DPIUtil.autoScaleUp(wHint) : wHint;
+		hHint = hHint != SWT.DEFAULT ? DPIUtil.autoScaleUp(hHint) : hHint;
+		return DPIUtil.autoScaleDown(computeSizePixels(wHint, hHint, changed));
+	}
+
+	private Point computeSizePixels(int wHint, int hHint, boolean changed) {
+		int width = DEFAULT_WIDTH;
+		int height = DEFAULT_HEIGHT;
+		if (wHint != SWT.DEFAULT) {
+			width = wHint;
+		}
+		if (hHint != SWT.DEFAULT) {
+			height = hHint;
+		}
+		final int border = getBorderWidth();
+		width += border * 2;
+		height += border * 2;
+		return new Point(width, height);
+	}
+
+	/**
+	 * Returns <code>true</code> if the receiver is grayed, and false otherwise.
+	 *
+	 * @return the grayed state of the checkbox
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 *
+	 * @since 3.4
+	 */
+	public boolean getGrayed() {
+		checkWidget();
+		return grayed;
+	}
+
+	/**
+	 * Returns the receiver's color when the mouse is hover the widget.
+	 * 
+	 * @return the receiver's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getHoverColor() {
+		checkWidget();
+		return hoverColor;
+	}
+
+	/**
+	 * Returns the receiver's background color when the widget is selected.
+	 * 
+	 * @return the background color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getSelectedBackgroundColor() {
+		checkWidget();
+		return selectionBackground;
+	}
+
+	/**
+	 * Returns the receiver's foreground color when the widget is selected.
+	 * 
+	 * @return the foreground color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getSelectedForegroundColor() {
+		checkWidget();
+		return selectionForeground;
+	}
+
+	/**
+	 * Returns <code>true</code> if the receiver is selected, and false otherwise.
+	 *
+	 * @return the selection state
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public boolean getSelection() {
+		checkWidget();
+		return selected;
+	}
+
+	/**
+	 * Returns the receiver's foreground color when the widget is not selected.
+	 * 
+	 * @return the foreground color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getUnselectedColor() {
+		checkWidget();
+		return unselectedColor;
+	}
+
+	/**
+	 * Removes the listener from the collection of listeners who will be notified
+	 * when the control is selected by the user.
+	 *
+	 * @param listener the listener which should no longer be notified
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the listener
+	 *                                     is null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 *
+	 * @see SelectionListener
+	 * @see #addSelectionListener
+	 */
+	public void removeSelectionListener(final SelectionListener listener) {
+		removeTypedListener(SWT.Selection, listener);
+	}
+
+	/**
+	 * Sets the grayed state of the receiver. This state change only applies if the
+	 * control was created with the SWT.CHECK style.
+	 *
+	 * @param grayed the new grayed state
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public void setGrayed(boolean grayed) {
+		checkWidget();
+		this.grayed = grayed;
+		redraw();
+		update();
+	}
+
+	/**
+	 * Sets the button's color when the mouse is hover the widget to the color
+	 * specified by the argument, or to the default system color for the control if
+	 * the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setHoverColor(Color color) {
+		checkWidget();
+		if (color == null) {
+			hoverColor = getAndDisposeColor(56, 143, 188);
+		} else {
+			hoverColor = color;
+		}
+	}
+
+	/**
+	 * Sets the button's background color when the widget is selected to the color
+	 * specified by the argument, or to the default system color for the control if
+	 * the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setSelectedBackgroundColor(Color color) {
+		checkWidget();
+		if (color == null) {
+			selectionBackground = getAndDisposeColor(0, 122, 255);
+		} else {
+			selectionBackground = color;
+		}
+	}
+
+	/**
+	 * Sets the button's foreground color when the widget is selected to the color
+	 * specified by the argument, or to the default system color for the control if
+	 * the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setSelectedForegroundColor(Color color) {
+		checkWidget();
+		if (color == null) {
+			selectionForeground = getAndDisposeColor(255, 255, 255);
+		} else {
+			selectionForeground = color;
+		}
+	}
+
+	/**
+	 * Sets the selection state of the receiver.
+	 *
+	 * @param selected the new selection state
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public void setSelection(boolean selected) {
+		checkWidget();
+		this.selected = selected;
+		redraw();
+		update();
+	}
+
+	/**
+	 * Sets the button's drawing color when the widget is not selected to the color
+	 * specified by the argument, or to the default system color for the control if
+	 * the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setUnselectedColor(Color color) {
+		checkWidget();
+		if (color == null) {
+			unselectedColor = getAndDisposeColor(204, 204, 204);
+		} else {
+			unselectedColor = color;
+		}
+	}
+
+}

--- a/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/RoundedSwitch.java
+++ b/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/RoundedSwitch.java
@@ -1,0 +1,953 @@
+package com.tlcsdm.tlstudio.widgets.custom;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.internal.DPIUtil;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+
+/**
+ * Instances of this class provide a checkbox button displayed as a switch.<br/>
+ * Please notive that this widget draws only the checkbox (you can not attach a
+ * text like regular <code>Button</code> SWT Widget)
+ * <p>
+ * <dl>
+ * <dt><b>Styles:</b></dt>
+ * <dd>BORDER</dd>
+ * <dt><b>Events:</b></dt>
+ * <dd>Selection</dd>
+ * </dl>
+ * </p>
+ */
+@SuppressWarnings("restriction")
+public class RoundedSwitch extends AbstractCustomCanvas {
+
+	// Presentation
+	private int borderWidth;
+	private RoundedSwitchConfiguration checkedEnabledConfiguration;
+	private RoundedSwitchConfiguration uncheckedEnabledConfiguration;
+	private RoundedSwitchConfiguration checkedDisabledConfiguration;
+	private RoundedSwitchConfiguration uncheckedDisabledConfiguration;
+
+	private static final int DEFAULT_WIDTH = 45;
+	private static final int DEFAULT_HEIGHT = 20;
+	private boolean selected;
+	private GC gc;
+
+	/**
+	 * Constructs a new instance of this class given its parent and a style value
+	 * describing its behavior and appearance.
+	 * <p>
+	 * The style value is either one of the style constants defined in class
+	 * <code>SWT</code> which is applicable to instances of this class, or must be
+	 * built by <em>bitwise OR</em>'ing together (that is, using the
+	 * <code>int</code> "|" operator) two or more of those <code>SWT</code> style
+	 * constants. The class description lists the style constants that are
+	 * applicable to the class. Style bits are also inherited from superclasses.
+	 * </p>
+	 *
+	 * @param parent a composite control which will be the parent of the new
+	 *               instance (cannot be null)
+	 * @param style  the style of control to construct
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the parent
+	 *                                     is null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     parent</li>
+	 *                                     </ul>
+	 *
+	 */
+	public RoundedSwitch(Composite parent, int style) {
+		super(parent, checkStyle(style) | SWT.DOUBLE_BUFFERED);
+		selected = false;
+		borderWidth = 2;
+		checkedEnabledConfiguration = RoundedSwitchConfiguration.createCheckedEnabledConfiguration(this);
+		uncheckedEnabledConfiguration = RoundedSwitchConfiguration.createUncheckedEnabledConfiguration(this);
+		checkedDisabledConfiguration = RoundedSwitchConfiguration.createCheckedDisabledConfiguration(this);
+		uncheckedDisabledConfiguration = RoundedSwitchConfiguration.createUncheckedDisabledConfiguration(this);
+
+		addListener(SWT.Paint, e -> {
+			gc = e.gc;
+			drawWidget();
+		});
+
+		addListener(SWT.MouseUp, e -> onClick(e));
+		addListener(SWT.KeyUp, e -> onKeyPress(e));
+
+		addListener(SWT.MouseEnter, e -> {
+			if (!isEnabled()) {
+				return;
+			}
+			setCursor(getDisplay().getSystemCursor(SWT.CURSOR_HAND));
+		});
+		addListener(SWT.MouseExit, e -> {
+			if (!isEnabled())
+				return;
+			setCursor(getDisplay().getSystemCursor(SWT.CURSOR_ARROW));
+		});
+	}
+
+	private static int checkStyle(final int style) {
+		if ((style & SWT.BORDER) != 0) {
+			return style & ~SWT.BORDER;
+		}
+		return 0;
+	}
+
+	private void drawWidget() {
+		gc.setAdvanced(true);
+		gc.setAntialias(SWT.ON);
+		final Color previousForeground = gc.getForeground();
+		final Color previousBackground = gc.getBackground();
+
+		if (isEnabled()) {
+			if (selected) {
+				drawCheckedEnabled();
+			} else {
+				drawUncheckedEnabled();
+			}
+		} else {
+			if (selected) {
+				drawCheckedDisabled();
+			} else {
+				drawUncheckedDisabled();
+			}
+		}
+
+		gc.setBackground(previousBackground);
+		gc.setForeground(previousForeground);
+	}
+
+	private void drawCheckedEnabled() {
+		gc.setBackground(checkedEnabledConfiguration.backgroundColor);
+		drawOuterRoundedRectangle();
+		gc.setForeground(checkedEnabledConfiguration.borderColor);
+		drawBorderRoundedRectangle();
+		gc.setBackground(checkedEnabledConfiguration.circleColor);
+		drawCircle();
+	}
+
+	private void drawOuterRoundedRectangle() {
+		final int width = getSize().x;
+		final int height = getSize().y;
+		gc.fillRoundRectangle(2, 2, width - 4, height - 4, height - 4, height - 4);
+	}
+
+	private void drawBorderRoundedRectangle() {
+		if (gc.getForeground().equals(gc.getBackground())) {
+			return;
+		}
+		final int width = getSize().x;
+		final int height = getSize().y;
+		gc.setLineWidth(borderWidth);
+		gc.drawRoundRectangle(2, 2, width - 4, height - 4, height - 4, height - 4);
+	}
+
+	private void drawCircle() {
+		final int width = getSize().x;
+		final int height = getSize().y;
+		int x;
+		if (selected) {
+			x = width - height + 4;
+		} else {
+			x = 6;
+		}
+		gc.fillOval(x, 5, height - 10, height - 10);
+	}
+
+	private void drawUncheckedEnabled() {
+		gc.setBackground(uncheckedEnabledConfiguration.backgroundColor);
+		drawOuterRoundedRectangle();
+		gc.setForeground(uncheckedEnabledConfiguration.borderColor);
+		drawBorderRoundedRectangle();
+		gc.setBackground(uncheckedEnabledConfiguration.circleColor);
+		drawCircle();
+	}
+
+	private void drawCheckedDisabled() {
+		gc.setBackground(checkedDisabledConfiguration.backgroundColor);
+		drawOuterRoundedRectangle();
+		gc.setForeground(checkedDisabledConfiguration.borderColor);
+		drawBorderRoundedRectangle();
+		gc.setBackground(checkedDisabledConfiguration.circleColor);
+		drawCircle();
+	}
+
+	private void drawUncheckedDisabled() {
+		gc.setBackground(uncheckedDisabledConfiguration.backgroundColor);
+		drawOuterRoundedRectangle();
+		gc.setForeground(uncheckedDisabledConfiguration.borderColor);
+		drawOuterRoundedRectangle();
+		gc.setBackground(uncheckedDisabledConfiguration.circleColor);
+		drawCircle();
+	}
+
+	private void onClick(Event e) {
+		if (!isEnabled()) {
+			return;
+		}
+		if (fireSelectionListeners(this, e)) {
+			setSelection(!selected);
+		}
+	}
+
+	private void onKeyPress(Event e) {
+		if (!isEnabled()) {
+			return;
+		}
+		if (e.character == ' ' || e.character == '+') {
+			setSelection(!selected);
+		}
+	}
+
+	/**
+	 * Adds the listener to the collection of listeners who will be notified when
+	 * the control is selected by the user, by sending it one of the messages
+	 * defined in the <code>SelectionListener</code> interface.
+	 * <p>
+	 * <code>widgetDefaultSelected</code> is not called.
+	 * </p>
+	 *
+	 * @param listener the listener which should be notified when the control is
+	 *                 selected by the user,
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the listener
+	 *                                     is null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 *
+	 * @see SelectionListener
+	 * @see #removeSelectionListener
+	 * @see SelectionEvent
+	 */
+	public void addSelectionListener(final SelectionListener listener) {
+		addTypedListener(listener, SWT.Selection);
+	}
+
+	/**
+	 * @see org.eclipse.swt.widgets.Control#computeSize(int, int, boolean)
+	 */
+	@Override
+	public Point computeSize(int wHint, int hHint, boolean changed) {
+		wHint = wHint != SWT.DEFAULT ? DPIUtil.autoScaleUp(wHint) : wHint;
+		hHint = hHint != SWT.DEFAULT ? DPIUtil.autoScaleUp(hHint) : hHint;
+		return DPIUtil.autoScaleDown(computeSizePixels(wHint, hHint, changed));
+	}
+
+	private Point computeSizePixels(int wHint, int hHint, boolean changed) {
+		int width = DEFAULT_WIDTH;
+		int height = DEFAULT_HEIGHT;
+		if (wHint != SWT.DEFAULT) {
+			width = wHint;
+		}
+		if (hHint != SWT.DEFAULT) {
+			height = hHint;
+		}
+		final int border = getBorderWidth();
+		width += border * 2;
+		height += border * 2;
+		return new Point(width, height);
+	}
+
+	/**
+	 * Returns <code>true</code> if the receiver is selected, and false otherwise.
+	 *
+	 * @return the selection state
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public boolean getSelection() {
+		checkWidget();
+		return selected;
+	}
+
+	/**
+	 * Removes the listener from the collection of listeners who will be notified
+	 * when the control is selected by the user.
+	 *
+	 * @param listener the listener which should no longer be notified
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the listener
+	 *                                     is null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 *
+	 * @see SelectionListener
+	 * @see #addSelectionListener
+	 */
+	public void removeSelectionListener(final SelectionListener listener) {
+		removeTypedListener(SWT.Selection, listener);
+	}
+
+	/**
+	 * Sets the selection state of the receiver.
+	 *
+	 * @param selected the new selection state
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public void setSelection(boolean selected) {
+		checkWidget();
+		this.selected = selected;
+		redraw();
+		update();
+	}
+
+	// -------- Getter & Setter for border width and color configuration
+	/**
+	 * Returns the receiver's border width
+	 * 
+	 * @return the border width
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public int getBorderWidth() {
+		checkWidget();
+		return borderWidth;
+	}
+
+	/**
+	 * Sets the receiver's border width
+	 *
+	 * @param borderWidth the new border width
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public void setBorderWidth(int borderWidth) {
+		checkWidget();
+		this.borderWidth = borderWidth;
+	}
+
+	// -- BORDER
+
+	/**
+	 * Returns the border's color when the widget is checked and enabled.
+	 * 
+	 * @return the border's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getBorderColorCheckedEnabled() {
+		checkWidget();
+		return checkedEnabledConfiguration.borderColor;
+	}
+
+	/**
+	 * Sets the border's color when when the widget is checked and enabled or to the
+	 * default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setBorderColorCheckedEnabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createCheckedEnabledConfiguration(this);
+			checkedEnabledConfiguration.borderColor = temp.borderColor;
+		} else {
+			checkedEnabledConfiguration.borderColor = color;
+		}
+	}
+
+	/**
+	 * Returns the border's color when the widget is unchecked and enabled.
+	 * 
+	 * @return the border's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getBorderColorUncheckedEnabled() {
+		checkWidget();
+		return uncheckedEnabledConfiguration.borderColor;
+	}
+
+	/**
+	 * Sets the border's color when when the widget is unchecked and enabled or to
+	 * the default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setBorderColorUncheckedEnabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createUncheckedEnabledConfiguration(this);
+			uncheckedEnabledConfiguration.borderColor = temp.borderColor;
+		} else {
+			uncheckedEnabledConfiguration.borderColor = color;
+		}
+	}
+
+	/**
+	 * Returns the border's color when the widget is checked and disabled.
+	 * 
+	 * @return the border's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getBorderColorCheckedDisabled() {
+		checkWidget();
+		return checkedDisabledConfiguration.borderColor;
+	}
+
+	/**
+	 * Sets the border's color when when the widget is checked and disabled or to
+	 * the default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setBorderColorCheckedDisabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createCheckedDisabledConfiguration(this);
+			checkedDisabledConfiguration.borderColor = temp.borderColor;
+		} else {
+			checkedDisabledConfiguration.borderColor = color;
+		}
+	}
+
+	/**
+	 * Returns the border's color when the widget is unchecked and disabled.
+	 * 
+	 * @return the border's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getBorderColorUncheckedDisabled() {
+		checkWidget();
+		return uncheckedDisabledConfiguration.borderColor;
+	}
+
+	/**
+	 * Sets the border's color when when the widget is unchecked and disabled or to
+	 * the default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setBorderColorUncheckedDisabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createUncheckedDisabledConfiguration(this);
+			uncheckedDisabledConfiguration.borderColor = temp.borderColor;
+		} else {
+			uncheckedDisabledConfiguration.borderColor = color;
+		}
+	}
+
+	// -- CIRCLE
+	/**
+	 * Returns the circle's color when the widget is checked and enabled.
+	 * 
+	 * @return the circle's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getCircleColorCheckedEnabled() {
+		checkWidget();
+		return checkedEnabledConfiguration.circleColor;
+	}
+
+	/**
+	 * Sets the circle's color when when the widget is checked and enabled or to the
+	 * default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setCircleColorCheckedEnabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createCheckedEnabledConfiguration(this);
+			checkedEnabledConfiguration.circleColor = temp.circleColor;
+		} else {
+			checkedEnabledConfiguration.circleColor = color;
+		}
+	}
+
+	/**
+	 * Returns the circle's color when the widget is unchecked and enabled.
+	 * 
+	 * @return the circle's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getCircleColorUncheckedEnabled() {
+		checkWidget();
+		return uncheckedEnabledConfiguration.circleColor;
+	}
+
+	/**
+	 * Sets the circle's color when when the widget is unchecked and enabled or to
+	 * the default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setCircleColorUncheckedEnabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createUncheckedEnabledConfiguration(this);
+			uncheckedEnabledConfiguration.circleColor = temp.circleColor;
+		} else {
+			uncheckedEnabledConfiguration.circleColor = color;
+		}
+	}
+
+	/**
+	 * Returns the circle's color when the widget is checked and disabled.
+	 * 
+	 * @return the circle's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getCircleColorCheckedDisabled() {
+		checkWidget();
+		return checkedDisabledConfiguration.circleColor;
+	}
+
+	/**
+	 * Sets the circle's color when when the widget is checked and disabled or to
+	 * the default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setCircleColorCheckedDisabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createCheckedDisabledConfiguration(this);
+			checkedDisabledConfiguration.circleColor = temp.circleColor;
+		} else {
+			checkedDisabledConfiguration.circleColor = color;
+		}
+	}
+
+	/**
+	 * Returns the circle's color when the widget is unchecked and disabled.
+	 * 
+	 * @return the circle's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getCircleColorUncheckedDisabled() {
+		checkWidget();
+		return uncheckedDisabledConfiguration.circleColor;
+	}
+
+	/**
+	 * Sets the circle's color when when the widget is unchecked and disabled or to
+	 * the default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setCircleColorUncheckedDisabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createUncheckedDisabledConfiguration(this);
+			uncheckedDisabledConfiguration.circleColor = temp.circleColor;
+		} else {
+			uncheckedDisabledConfiguration.circleColor = color;
+		}
+	}
+
+	// -- Background
+	/**
+	 * Returns the background's color when the widget is checked and enabled.
+	 * 
+	 * @return the background's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getBackgroundColorCheckedEnabled() {
+		checkWidget();
+		return checkedEnabledConfiguration.backgroundColor;
+	}
+
+	/**
+	 * Sets the background's color when when the widget is checked and enabled or to
+	 * the default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setBackgroundColorCheckedEnabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createCheckedEnabledConfiguration(this);
+			checkedEnabledConfiguration.backgroundColor = temp.backgroundColor;
+		} else {
+			checkedEnabledConfiguration.backgroundColor = color;
+		}
+	}
+
+	/**
+	 * Returns the background's color when the widget is unchecked and enabled.
+	 * 
+	 * @return the background's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getBackgroundColorUncheckedEnabled() {
+		checkWidget();
+		return uncheckedEnabledConfiguration.backgroundColor;
+	}
+
+	/**
+	 * Sets the background's color when when the widget is unchecked and enabled or
+	 * to the default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setBackgroundColorUncheckedEnabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createUncheckedEnabledConfiguration(this);
+			uncheckedEnabledConfiguration.backgroundColor = temp.backgroundColor;
+		} else {
+			uncheckedEnabledConfiguration.backgroundColor = color;
+		}
+	}
+
+	/**
+	 * Returns the background's color when the widget is checked and disabled.
+	 * 
+	 * @return the background's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getBackgroundColorCheckedDisabled() {
+		checkWidget();
+		return checkedDisabledConfiguration.backgroundColor;
+	}
+
+	/**
+	 * Sets the background's color when when the widget is checked and disabled or
+	 * to the default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setBackgroundColorCheckedDisabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createCheckedDisabledConfiguration(this);
+			checkedDisabledConfiguration.backgroundColor = temp.backgroundColor;
+		} else {
+			checkedDisabledConfiguration.backgroundColor = color;
+		}
+	}
+
+	/**
+	 * Returns the background's color when the widget is unchecked and disabled.
+	 * 
+	 * @return the background's color
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public Color getBackgroundColorUncheckedDisabled() {
+		checkWidget();
+		return uncheckedDisabledConfiguration.backgroundColor;
+	}
+
+	/**
+	 * Sets the background's color when when the widget is unchecked and disabled or
+	 * to the default system color for the control if the argument is null.
+	 * 
+	 * @param color the new color (or null)
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_INVALID_ARGUMENT - if the
+	 *                                     argument has been disposed</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setBackgroundColorUncheckedDisabled(Color color) {
+		checkWidget();
+		if (color == null) {
+			RoundedSwitchConfiguration temp = RoundedSwitchConfiguration.createUncheckedDisabledConfiguration(this);
+			uncheckedDisabledConfiguration.backgroundColor = temp.backgroundColor;
+		} else {
+			uncheckedDisabledConfiguration.backgroundColor = color;
+		}
+	}
+}

--- a/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/RoundedSwitchConfiguration.java
+++ b/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/RoundedSwitchConfiguration.java
@@ -1,0 +1,56 @@
+package com.tlcsdm.tlstudio.widgets.custom;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Display;
+
+import com.tlcsdm.tlstudio.widgets.utils.SWTGraphicUtil;
+
+/**
+ * This class represents the configuration for a given state (enable
+ * state+selection state)
+ */
+class RoundedSwitchConfiguration {
+
+	Color borderColor;
+	Color circleColor;
+	Color backgroundColor;
+
+	private RoundedSwitchConfiguration(Color borderColor, Color circleColor, Color backgroundColor) {
+		this.borderColor = borderColor;
+		this.circleColor = circleColor;
+		this.backgroundColor = backgroundColor;
+	}
+
+	static RoundedSwitchConfiguration createCheckedEnabledConfiguration(RoundedSwitch parent) {
+		Display display = parent.getDisplay();
+		RoundedSwitchConfiguration config = new RoundedSwitchConfiguration(display.getSystemColor(SWT.COLOR_BLACK), //
+				display.getSystemColor(SWT.COLOR_WHITE), display.getSystemColor(SWT.COLOR_BLACK));
+		return config;
+	}
+
+	static RoundedSwitchConfiguration createUncheckedEnabledConfiguration(RoundedSwitch parent) {
+		Display display = parent.getDisplay();
+		RoundedSwitchConfiguration config = new RoundedSwitchConfiguration(display.getSystemColor(SWT.COLOR_BLACK), //
+				display.getSystemColor(SWT.COLOR_BLACK), display.getSystemColor(SWT.COLOR_WHITE));
+		return config;
+	}
+
+	static RoundedSwitchConfiguration createCheckedDisabledConfiguration(RoundedSwitch parent) {
+		Display display = parent.getDisplay();
+		Color lightGrey = new Color(display, 233, 233, 233);
+		Color darkGrey = new Color(display, 208, 208, 208);
+		SWTGraphicUtil.addDisposer(parent, lightGrey, darkGrey);
+		RoundedSwitchConfiguration config = new RoundedSwitchConfiguration(lightGrey, darkGrey, lightGrey);
+		return config;
+	}
+
+	static RoundedSwitchConfiguration createUncheckedDisabledConfiguration(RoundedSwitch parent) {
+		Display display = parent.getDisplay();
+		Color lightGrey = new Color(display, 233, 233, 233);
+		Color darkGrey = new Color(display, 208, 208, 208);
+		SWTGraphicUtil.addDisposer(parent, lightGrey, darkGrey);
+		RoundedSwitchConfiguration config = new RoundedSwitchConfiguration(lightGrey, darkGrey, lightGrey);
+		return config;
+	}
+}

--- a/examples/com.tlcsdm.tlstudio.widgets.snippets/src/com/tlcsdm/tlstudio/widgets/example/custom/RoundedCheckBoxSnippet.java
+++ b/examples/com.tlcsdm.tlstudio.widgets.snippets/src/com/tlcsdm/tlstudio/widgets/example/custom/RoundedCheckBoxSnippet.java
@@ -1,0 +1,109 @@
+package com.tlcsdm.tlstudio.widgets.example.custom;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+
+import com.tlcsdm.tlstudio.widgets.custom.RoundedCheckbox;
+import com.tlcsdm.tlstudio.widgets.utils.SWTGraphicUtil;
+
+/**
+ * This snippet demonstrates the RoundedCheckBox widget
+ *
+ */
+public class RoundedCheckBoxSnippet {
+
+	/**
+	 * @param args
+	 */
+	public static void main(final String[] args) {
+		final Display display = new Display();
+		final Shell shell = new Shell(display);
+		shell.setLayout(new GridLayout(2, false));
+
+		// ------------------------- Checkboxes
+		final Label lbl1 = new Label(shell, SWT.NONE);
+		lbl1.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl1.setText("Simple Checkbox (2 states)");
+
+		final Button button1 = new Button(shell, SWT.CHECK);
+		button1.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+
+		final Label lbl2 = new Label(shell, SWT.NONE);
+		lbl2.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl2.setText("Simple Checkbox (Inderminate)");
+
+		final Button button2 = new Button(shell, SWT.CHECK);
+		button2.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+		button2.setGrayed(true);
+
+		// ------------------------- Rounded Checkboxes
+		final Label lbl3 = new Label(shell, SWT.NONE);
+		lbl3.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl3.setText("Rounded Checkbox (2 states)");
+
+		final RoundedCheckbox button3 = new RoundedCheckbox(shell, SWT.NONE);
+		button3.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+
+		final Label lbl4 = new Label(shell, SWT.NONE);
+		lbl4.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl4.setText("Rounded Checkbox (2 states, selected)");
+
+		final RoundedCheckbox button4 = new RoundedCheckbox(shell, SWT.NONE);
+		button4.setSelection(true);
+		button4.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+
+		final Label lbl5 = new Label(shell, SWT.NONE);
+		lbl5.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl5.setText("Rounded Checkbox (3 states, selected)");
+
+		final RoundedCheckbox button5 = new RoundedCheckbox(shell, SWT.NONE);
+		button5.setSelection(true);
+		button5.setGrayed(true);
+		button5.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+
+		// ------------------------- Rounded Checkboxes
+		final Label lbl6 = new Label(shell, SWT.NONE);
+		lbl6.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl6.setText("Rounded Checkbox (Disabled,2 states)");
+
+		final RoundedCheckbox button6 = new RoundedCheckbox(shell, SWT.NONE);
+		button6.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+		button6.setEnabled(false);
+
+		final Label lbl7 = new Label(shell, SWT.NONE);
+		lbl7.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl7.setText("Rounded Checkbox (Disabled,2 states, selected)");
+
+		final RoundedCheckbox button7 = new RoundedCheckbox(shell, SWT.NONE);
+		button7.setSelection(true);
+		button7.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+		button7.setEnabled(false);
+
+		final Label lbl8 = new Label(shell, SWT.NONE);
+		lbl8.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl8.setText("Rounded Checkbox (Disabled,3 states, selected)");
+
+		final RoundedCheckbox button8 = new RoundedCheckbox(shell, SWT.NONE);
+		button8.setSelection(true);
+		button8.setGrayed(true);
+		button8.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+		button8.setEnabled(false);
+
+		shell.setSize(400, 350);
+		shell.open();
+		SWTGraphicUtil.centerShell(shell);
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+
+		display.dispose();
+	}
+}

--- a/examples/com.tlcsdm.tlstudio.widgets.snippets/src/com/tlcsdm/tlstudio/widgets/example/custom/RoundedSwitchSnippet.java
+++ b/examples/com.tlcsdm.tlstudio.widgets.snippets/src/com/tlcsdm/tlstudio/widgets/example/custom/RoundedSwitchSnippet.java
@@ -1,0 +1,78 @@
+package com.tlcsdm.tlstudio.widgets.example.custom;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+
+import com.tlcsdm.tlstudio.widgets.custom.RoundedSwitch;
+import com.tlcsdm.tlstudio.widgets.utils.SWTGraphicUtil;
+
+/**
+ * This snippet demonstrates the RoundedSwitch widget
+ *
+ */
+public class RoundedSwitchSnippet {
+
+	/**
+	 * @param args
+	 */
+	public static void main(final String[] args) {
+		final Display display = new Display();
+		final Shell shell = new Shell(display);
+		shell.setLayout(new GridLayout(2, false));
+
+		final Label lbl1 = new Label(shell, SWT.NONE);
+		lbl1.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl1.setText("Enabled checked");
+
+		final RoundedSwitch button1 = new RoundedSwitch(shell, SWT.NONE);
+		button1.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+		button1.setEnabled(true);
+		button1.setSelection(true);
+		button1.addListener(SWT.Selection, e -> {
+			System.out.println("Click");
+		});
+
+		final Label lbl2 = new Label(shell, SWT.NONE);
+		lbl2.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl2.setText("Enabled unchecked");
+
+		final RoundedSwitch button2 = new RoundedSwitch(shell, SWT.NONE);
+		button2.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+		button2.setEnabled(true);
+		button2.setSelection(false);
+
+		final Label lbl3 = new Label(shell, SWT.NONE);
+		lbl3.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl3.setText("Disabled checked");
+
+		final RoundedSwitch button3 = new RoundedSwitch(shell, SWT.NONE);
+		button3.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+		button3.setEnabled(false);
+		button3.setSelection(true);
+
+		final Label lbl4 = new Label(shell, SWT.NONE);
+		lbl4.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
+		lbl4.setText("Disabled unchecked");
+
+		final RoundedSwitch button4 = new RoundedSwitch(shell, SWT.NONE);
+		button4.setLayoutData(new GridData(GridData.CENTER, GridData.CENTER, false, false));
+		button4.setEnabled(false);
+		button4.setSelection(false);
+
+		shell.setSize(400, 350);
+		shell.open();
+		SWTGraphicUtil.centerShell(shell);
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+
+		display.dispose();
+	}
+}


### PR DESCRIPTION
Close #315

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Implement custom rounded switch and checkbox SWT widgets with configurable styles and states, along with helper configuration and usage examples.

New Features:
- Add RoundedSwitch custom SWT widget with enabled/disabled and checked/unchecked styling.
- Add RoundedCheckbox custom SWT widget with two-state, grayed three-state support, hover effects, and custom colors.
- Introduce RoundedSwitchConfiguration helper for managing switch state colors and borders.
- Include example snippet applications demonstrating usage of RoundedSwitch and RoundedCheckbox widgets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a rounded checkbox widget with customizable appearance and support for two-state and three-state (indeterminate) modes.
  - Added a rounded switch toggle widget with configurable colors and border styles for various states.
- **Documentation**
  - Provided example applications demonstrating the usage and different states of the new rounded checkbox and switch widgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->