### PR TITLE
feat: Add DialogComboCellEditor

### DIFF
--- a/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/viewers/DialogComboCellEditor.java
+++ b/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/viewers/DialogComboCellEditor.java
@@ -1,0 +1,183 @@
+package com.tlcsdm.tlstudio.widgets.viewers;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+/**
+ * 功能不稳定，需要在生产环境校验
+ */
+@Deprecated
+public class DialogComboCellEditor extends CellEditor {
+
+	private String value;
+	private List<String> allItems;
+	private Composite editorComposite;
+
+	public DialogComboCellEditor(Composite parent, List<String> items) {
+		super(parent);
+		this.allItems = items;
+	}
+
+	@Override
+	protected Control createControl(Composite parent) {
+		// 用Composite代替Label，避免布局相关问题
+		editorComposite = new Composite(parent, SWT.NONE);
+		editorComposite.setLayout(new GridLayout(1, false));
+		Label label = new Label(editorComposite, SWT.NONE);
+		label.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true));
+		return editorComposite;
+	}
+
+	@Override
+	protected void doSetFocus() {
+		openDialog();
+	}
+
+	@Override
+	protected Object doGetValue() {
+		return value;
+	}
+
+	@Override
+	protected void doSetValue(Object value) {
+		this.value = value == null ? "" : value.toString();
+		if (editorComposite != null && !editorComposite.isDisposed()) {
+			for (Control c : editorComposite.getChildren()) {
+				if (c instanceof Label) {
+					((Label) c).setText(this.value);
+					editorComposite.layout(); // 刷新布局
+					break;
+				}
+			}
+		}
+	}
+
+	@Override
+	public void activate() {
+		super.activate();
+		openDialog();
+	}
+
+	private void openDialog() {
+		if (editorComposite == null || editorComposite.isDisposed())
+			return;
+		Shell shell = editorComposite.getShell();
+		FilterDialog dialog = new FilterDialog(shell, allItems, value);
+		int result = dialog.open();
+		if (result == Window.OK) {
+			value = dialog.getSelectedValue();
+			if (editorComposite != null && !editorComposite.isDisposed()) {
+				for (Control c : editorComposite.getChildren()) {
+					if (c instanceof Label) {
+						((Label) c).setText(value);
+						editorComposite.layout();
+						break;
+					}
+				}
+			}
+			fireApplyEditorValue();
+		} else {
+			fireCancelEditor();
+		}
+		deactivate();
+	}
+
+	private static class FilterDialog extends Dialog {
+		private List<String> allItems;
+		private List<String> filteredItems;
+		private String selectedValue;
+		private String initialValue;
+
+		private Text filterText;
+		private org.eclipse.swt.widgets.List list;
+
+		protected FilterDialog(Shell parentShell, List<String> items, String initialValue) {
+			super(parentShell);
+			this.allItems = items;
+			this.initialValue = initialValue;
+			this.filteredItems = items;
+			this.selectedValue = initialValue;
+		}
+
+		@Override
+		protected Control createDialogArea(Composite parent) {
+			Composite container = (Composite) super.createDialogArea(parent);
+			container.setLayout(new GridLayout(2, false));
+
+			filterText = new Text(container, SWT.BORDER | SWT.SEARCH | SWT.ICON_CANCEL);
+			filterText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
+			filterText.setText("");
+
+			filterText.addModifyListener(e -> {
+				String filter = filterText.getText().toLowerCase();
+				filteredItems = allItems.stream().filter(item -> item.toLowerCase().contains(filter))
+						.collect(Collectors.toList());
+				refreshList();
+			});
+
+			list = new org.eclipse.swt.widgets.List(container, SWT.BORDER | SWT.V_SCROLL | SWT.SINGLE);
+			GridData listData = new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1);
+			list.setLayoutData(listData);
+
+			refreshList();
+
+			if (initialValue != null) {
+				int idx = filteredItems.indexOf(initialValue);
+				if (idx >= 0) {
+					list.select(idx);
+				}
+			}
+
+			list.addListener(SWT.Selection, e -> {
+				int idx = list.getSelectionIndex();
+				if (idx >= 0) {
+					selectedValue = filteredItems.get(idx);
+				}
+			});
+
+			return container;
+		}
+
+		private void refreshList() {
+			if (list == null || list.isDisposed())
+				return;
+			list.removeAll();
+			for (String item : filteredItems) {
+				list.add(item);
+			}
+			if (selectedValue != null) {
+				int idx = filteredItems.indexOf(selectedValue);
+				if (idx >= 0) {
+					list.select(idx);
+				}
+			}
+		}
+
+		@Override
+		protected void okPressed() {
+			int idx = list.getSelectionIndex();
+			if (idx >= 0) {
+				selectedValue = filteredItems.get(idx);
+			} else {
+				selectedValue = filterText.getText();
+			}
+			super.okPressed();
+		}
+
+		public String getSelectedValue() {
+			return selectedValue;
+		}
+	}
+}

--- a/examples/com.tlcsdm.tlstudio.widgets.snippets/src/com/tlcsdm/tlstudio/widgets/example/viewers/DialogComboCellEditorDemo.java
+++ b/examples/com.tlcsdm.tlstudio.widgets.snippets/src/com/tlcsdm/tlstudio/widgets/example/viewers/DialogComboCellEditorDemo.java
@@ -1,0 +1,87 @@
+package com.tlcsdm.tlstudio.widgets.example.viewers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.EditingSupport;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+import com.tlcsdm.tlstudio.widgets.viewers.DialogComboCellEditor;
+
+public class DialogComboCellEditorDemo {
+
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setText("DialogComboCellEditor Demo");
+		shell.setSize(400, 300);
+		shell.setLayout(new FillLayout());
+
+		// 原始数据和可选项
+		List<String> input = new ArrayList<>(Arrays.asList("Apple", "Banana"));
+		List<String> options = Arrays.asList("Apple", "Banana", "Orange", "Mango", "Grape", "Pineapple");
+
+		TableViewer viewer = new TableViewer(shell, SWT.BORDER | SWT.FULL_SELECTION);
+		viewer.getTable().setHeaderVisible(true);
+		viewer.getTable().setLinesVisible(true);
+
+		viewer.setContentProvider(ArrayContentProvider.getInstance());
+
+		TableViewerColumn column = new TableViewerColumn(viewer, SWT.NONE);
+		column.getColumn().setWidth(300);
+		column.getColumn().setText("Fruit");
+
+		column.setLabelProvider(new ColumnLabelProvider() {
+			@Override
+			public String getText(Object element) {
+				return element.toString();
+			}
+		});
+
+		column.setEditingSupport(new EditingSupport(viewer) {
+			@Override
+			protected CellEditor getCellEditor(Object element) {
+				return new DialogComboCellEditor(viewer.getTable(), options);
+			}
+
+			@Override
+			protected boolean canEdit(Object element) {
+				return true;
+			}
+
+			@Override
+			protected Object getValue(Object element) {
+				return element;
+			}
+
+			@Override
+			protected void setValue(Object element, Object value) {
+				int index = viewer.getTable().getSelectionIndex();
+				if (index >= 0 && index < input.size()) {
+					input.set(index, value.toString());
+					viewer.refresh();
+				}
+			}
+		});
+
+		viewer.setInput(input);
+
+		shell.open();
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
+		display.dispose();
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <maven.wagon.http.ssl.insecure>true</maven.wagon.http.ssl.insecure>
         <maven.wagon.http.ssl.allowall>true</maven.wagon.http.ssl.allowall>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
-        <flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
+        <flatten-maven-plugin.version>1.7.1</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -58,13 +58,13 @@
         <commons-codec.version>1.18.0</commons-codec.version>
         <commons-logging.version>1.3.5</commons-logging.version>
         <reflections.version>0.10.2</reflections.version>
-        <log4j2.version>2.24.3</log4j2.version>
+        <log4j2.version>2.25.0</log4j2.version>
         <log4j-over-slf4j.version>2.0.17</log4j-over-slf4j.version>
         <guava.version>33.4.8-jre</guava.version>
         <dom4j.version>2.1.4</dom4j.version>
         <pdfbox.version>3.0.5</pdfbox.version>
         <pdfviewfx.version>3.1.0</pdfviewfx.version>
-        <jackson.version>2.19.0</jackson.version>
+        <jackson.version>2.19.1</jackson.version>
         <groovy.version>4.0.27</groovy.version>
         <thumbnailator.version>0.4.20</thumbnailator.version>
         <gson.version>2.13.1</gson.version>
@@ -72,7 +72,7 @@
         <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
         <jaxb-runtime.version>4.0.5</jaxb-runtime.version>
         <asm.version>9.8</asm.version>
-        <classgraph.version>4.8.179</classgraph.version>
+        <classgraph.version>4.8.180</classgraph.version>
         <checker-qual.version>3.49.4</checker-qual.version>
     </properties>
 


### PR DESCRIPTION
Close #332

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Add a dialog-driven combo cell editor and its usage demo, and update several build dependencies to their latest patch releases.

New Features:
- Introduce DialogComboCellEditor to enable filtered dialog-based editing in JFace viewers
- Add DialogComboCellEditorDemo example showcasing the new cell editor in a table viewer

Enhancements:
- Bump flatten-maven-plugin, log4j2, jackson, and classgraph to newer patch versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dialog-based combo box cell editor for enhanced table editing, allowing users to filter and select from a list of options via a modal dialog.
  * Added a demonstration application showcasing the new cell editor within an editable table.

* **Chores**
  * Updated several dependency and plugin versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->