### PR TITLE
feat(widgets): Remove deprecated code

### DIFF
--- a/bundles/com.tlcsdm.tlstudio.widgets/META-INF/MANIFEST.MF
+++ b/bundles/com.tlcsdm.tlstudio.widgets/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Bundle-Vendor: TLCSDM
 Automatic-Module-Name: com.tlcsdm.tlstudio.widgets
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.eclipse.swt,
+Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.equinox.common,
  org.eclipse.osgi,
  org.eclipse.core.runtime,

--- a/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/AbstractCustomCanvas.java
+++ b/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/AbstractCustomCanvas.java
@@ -6,7 +6,6 @@ import java.lang.reflect.Method;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Resource;
@@ -16,7 +15,6 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
-import org.eclipse.swt.widgets.TypedListener;
 
 import com.tlcsdm.tlstudio.widgets.WidgetsUtility;
 
@@ -93,13 +91,14 @@ public abstract class AbstractCustomCanvas extends Canvas {
 	 * @param control  control on which the selection listener is added
 	 * @param listener listener to add
 	 */
-	protected void addSelectionListener(final Control control, final SelectionListener listener) {
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		TypedListener typedListener = new TypedListener(listener);
-		control.addListener(SWT.Selection, typedListener);
-	}
+	// For swt version < 3.126.0
+//	protected void addSelectionListener(final Control control, final SelectionListener listener) {
+//		if (listener == null) {
+//			SWT.error(SWT.ERROR_NULL_ARGUMENT);
+//		}
+//		TypedListener typedListener = new TypedListener(listener);
+//		control.addListener(SWT.Selection, typedListener);
+//	}
 
 	/**
 	 * Remove a <code>SelectionListener</code> of a given Control
@@ -107,20 +106,21 @@ public abstract class AbstractCustomCanvas extends Canvas {
 	 * @param control  control on which the selection listener is removed
 	 * @param listener listener to remove
 	 */
-	protected void removeSelectionListener(final Control control, final SelectionListener listener) {
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		final Listener[] listeners = control.getListeners(SWT.Selection);
-		for (Listener l : listeners) {
-			if (l instanceof TypedListener typedListener) {
-				if (typedListener.getEventListener() == listener) {
-					callMethod(control, "removeListener", SWT.Selection, typedListener.getEventListener());
-					return;
-				}
-			}
-		}
-	}
+	// For swt version < 3.126.0
+//	protected void removeSelectionListener(final Control control, final SelectionListener listener) {
+//		if (listener == null) {
+//			SWT.error(SWT.ERROR_NULL_ARGUMENT);
+//		}
+//		final Listener[] listeners = control.getListeners(SWT.Selection);
+//		for (Listener l : listeners) {
+//			if (l instanceof TypedListener typedListener) {
+//				if (typedListener.getEventListener() == listener) {
+//					callMethod(control, "removeListener", SWT.Selection, typedListener.getEventListener());
+//					return;
+//				}
+//			}
+//		}
+//	}
 
 	/**
 	 * Call a method using introspection (so ones can call a private or protected

--- a/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/RangeSlider.java
+++ b/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/RangeSlider.java
@@ -1023,8 +1023,7 @@ public class RangeSlider extends AbstractCustomCanvas {
 	 * @see #removeSelectionListener
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -1140,8 +1139,7 @@ public class RangeSlider extends AbstractCustomCanvas {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**

--- a/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/Slider.java
+++ b/bundles/com.tlcsdm.tlstudio.widgets/src/com/tlcsdm/tlstudio/widgets/custom/Slider.java
@@ -300,8 +300,7 @@ public class Slider extends AbstractCustomCanvas {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -340,8 +339,7 @@ public class Slider extends AbstractCustomCanvas {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**


### PR DESCRIPTION
For swt 3.126.0, remove TypedListener

Close #398

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Remove usage of deprecated SWT TypedListener APIs from custom widgets and rely on newer listener registration methods.

Enhancements:
- Update RangeSlider and Slider selection listener APIs to use addTypedListener/removeTypedListener instead of custom TypedListener helpers.
- Deprecate legacy helper methods for adding and removing SelectionListeners in AbstractCustomCanvas for SWT versions prior to 3.126.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints for improved platform compatibility.

* **Refactor**
  * Consolidated internal event listener management for widget components to streamline event handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->